### PR TITLE
hcloud/server: bump default image to ubuntu-22.04

### DIFF
--- a/module/server.nix
+++ b/module/server.nix
@@ -49,7 +49,7 @@ in
             ];
           };
           image = mkOption {
-            default = "ubuntu-18.04";
+            default = "ubuntu-22.04";
             type = str;
             description = ''
               image to spawn on the server

--- a/options.json
+++ b/options.json
@@ -343,7 +343,7 @@
         "url": "https://github.com/terranix/terranix-module-hcloud/tree/main/modulemodule/server.nix"
       }
     ],
-    "default": "ubuntu-18.04",
+    "default": "ubuntu-22.04",
     "description": "image to spawn on the server\n",
     "loc": [
       "hcloud",

--- a/options.md
+++ b/options.md
@@ -179,7 +179,7 @@ TF_VAR_hcloud_api_token.
 <li>
   <b><u>hcloud.server.&lt;name&gt;.image</u></b><br>
   <b>type</b>: string<br>
-  <b>default</b>: &#34;ubuntu-18.04&#34;<br>
+  <b>default</b>: &#34;ubuntu-22.04&#34;<br>
   <b>example</b>: null<br>
   <b>defined</b>: <a href="https://github.com/terranix/terranix-module-hcloud/tree/main/modulemodule/server.nix">module/server.nix</a><br>
   <b>description</b>: image to spawn on the server


### PR DESCRIPTION
`ubuntu-18.04` images will be dropped from Hetzner Cloud in 2023-08 and right now you can only use them when setting `allow_deprecated_images` to `true`.